### PR TITLE
Fixed 4 flaky tests in RequesterTest.java

### DIFF
--- a/manifold-deps-parent/manifold-json-rt/src/main/java/manifold/json/rt/api/Requester.java
+++ b/manifold-deps-parent/manifold-json-rt/src/main/java/manifold/json/rt/api/Requester.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -161,7 +162,7 @@ public class Requester<T>
   {
     if( _parameters.isEmpty() )
     {
-      _parameters = new HashMap<>( 2 );
+      _parameters = new LinkedHashMap<>( 2 );
     }
     _parameters.put( name, value );
     return this;


### PR DESCRIPTION
This PR fixes 1 possible test failure in module manifold-deps-parent/manifold-json-test

1. Test that could fail

Module: manifold-deps-parent/manifold-json-test
Class Name: manifold.api.json.RequesterTest
Test Names: httpGetRequestWithParameterizedUrlSuffixWithParams, httpGetRequestWithParams, httpPostRequestWithParameterizedUrlSuffixWithParams, httpPostRequestWithParams

2. Why the test might fail?

The tests httpGetRequestWithParameterizedUrlSuffixWithParams, httpGetRequestWithParams, httpPostRequestWithParameterizedUrlSuffixWithParams, httpPostRequestWithParams in RequesterTest.java are creating objects for the Requester class. 
Requester.java returns a HashMap 
https://github.com/harshith2000/manifold/blob/4f8d5c73cf0e2999d811f80a2101dc3723b273f5/manifold-deps-parent/manifold-json-rt/src/main/java/manifold/json/rt/api/Requester.java#L164

According to the official [documentation](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html), HashMap in Java does not maintain the order of the elements inserted. Because we insert two parameters here, 
```
.withParam( "foo", "bar" )
.withParam( "abc", "8" );
```
This order is not guaranteed while checking. 

Since there is no guarantee in the order of exception types returned, the order might change, resulting in the test failure.

3. How to reproduce?

I used an open-source tool called [NonDex](https://github.com/TestingResearchIllinois/NonDex) for detecting the assumption by shuffling the order of returned exception types.
Running the following commands will test the aforementioned operation
Clone the Repo
```
https://github.com/manifold-systems/manifold
```

Compile the module byte-buddy-dep
```
mvn clean install -pl manifold-deps-parent/manifold-json-test -am -DskipTests
```

(Optional) Run the unit test
```
mvn -pl manifold-deps-parent/manifold-json-test test -Dtest=manifold.api.json.RequesterTest#httpGetRequestWithParameterizedUrlSuffixWithParams
```

Run the unit test using NonDex
```
mvn -pl manifold-deps-parent/manifold-json-test edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=manifold.api.json.RequesterTest#httpGetRequestWithParameterizedUrlSuffixWithParams
```

3. How I fixed?

Since HashMap does not maintain the order of the elements in which they are inserted, we can use a LinkedHashMap instead. According to the official [documentation](https://docs.oracle.com/javase/8/docs/api/java/util/LinkedHashMap.html), LinkedHashMap preserves the order in which the elements are inserted, thereby, fixing the flakiness.